### PR TITLE
Feature/statique clean

### DIFF
--- a/src/main/java/ch/heig/statique/Commands/Clean.java
+++ b/src/main/java/ch/heig/statique/Commands/Clean.java
@@ -26,9 +26,7 @@ public class Clean implements Callable<Integer> {
                 }
             }
         }
-        if (!file.delete()) {
-            throw new IOException("Failed to delete " + file);
-        }
+        file.delete();
     }
 
     @Override

--- a/src/main/java/ch/heig/statique/Commands/Clean.java
+++ b/src/main/java/ch/heig/statique/Commands/Clean.java
@@ -2,6 +2,8 @@ package ch.heig.statique.Commands;
 
 import picocli.CommandLine;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
@@ -12,8 +14,27 @@ import java.util.concurrent.Callable;
 )
 public class Clean implements Callable<Integer> {
 
+    @CommandLine.Parameters(index = "0", description = "The file whose checksum to calculate.")
+    String file;
+
+    void deleteDirectoryRecursionJava6(File file) throws IOException {
+        if (file.isDirectory()) {
+            File[] entries = file.listFiles();
+            if (entries != null) {
+                for (File entry : entries) {
+                    deleteDirectoryRecursionJava6(entry);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new IOException("Failed to delete " + file);
+        }
+    }
+
     @Override
     public Integer call() throws Exception {
+        File f = new File(System.getProperty("user.dir")+ "\\site" + file + "\\build");
+        deleteDirectoryRecursionJava6(f);
         return 0;
     }
 }

--- a/src/main/java/ch/heig/statique/Commands/Clean.java
+++ b/src/main/java/ch/heig/statique/Commands/Clean.java
@@ -17,7 +17,7 @@ public class Clean implements Callable<Integer> {
     @CommandLine.Parameters(index = "0", description = "The file whose checksum to calculate.")
     String file;
 
-    void deleteDirectoryRecursionJava6(File file) throws IOException {
+    void deleteDirectoryRecursionJava6(File file) {
         if (file.isDirectory()) {
             File[] entries = file.listFiles();
             if (entries != null) {

--- a/src/main/java/ch/heig/statique/Commands/Clean.java
+++ b/src/main/java/ch/heig/statique/Commands/Clean.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable;
 )
 public class Clean implements Callable<Integer> {
 
-    @CommandLine.Parameters(index = "0", description = "The file whose checksum to calculate.")
+    @CommandLine.Parameters(index = "0", description = "The directory where the static site was initiated")
     String file;
 
     void deleteDirectoryRecursionJava6(File file) {

--- a/src/main/java/ch/heig/statique/Commands/Clean.java
+++ b/src/main/java/ch/heig/statique/Commands/Clean.java
@@ -3,7 +3,6 @@ package ch.heig.statique.Commands;
 import picocli.CommandLine;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
@@ -17,12 +16,12 @@ public class Clean implements Callable<Integer> {
     @CommandLine.Parameters(index = "0", description = "The directory where the static site was initiated")
     String file;
 
-    void deleteDirectoryRecursionJava6(File file) {
+    void deleteDirectory(File file) {
         if (file.isDirectory()) {
             File[] entries = file.listFiles();
             if (entries != null) {
                 for (File entry : entries) {
-                    deleteDirectoryRecursionJava6(entry);
+                    deleteDirectory(entry);
                 }
             }
         }
@@ -32,7 +31,7 @@ public class Clean implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         File f = new File(System.getProperty("user.dir")+ "\\site" + file + "\\build");
-        deleteDirectoryRecursionJava6(f);
+        deleteDirectory(f);
         return 0;
     }
 }


### PR DESCRIPTION
Close #23
Implémentation du nettoyage de site avec la commande _statique clean <path>_. Path étant le chemin spécifié lors de l'initialisation du site. Cette commande va supprimer le dossier /site/<path>/build et son contenu.